### PR TITLE
Update RedHat / CentOS PHP CLI package name

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,7 @@ class composer::params {
       $tmp_path        = '/tmp'
       $php_package     = 'php5-cli'
     }
-    'RedHat', 'CentOS': {
+    'RedHat': {
       $target_dir      = '/usr/local/bin'
       $composer_file   = 'composer'
       $download_method = 'curl'


### PR DESCRIPTION
On RedHat and CentOS systems the PHP CLI binary is provided by the `php-cli` package:

http://pkgs.org/search/?keyword=php-cli&search_on=name&distro=82&exact=1

Also removed `CentOS` from the `$::osfamily` case check as it isn't actually an OS family:

https://github.com/puppetlabs/facter/blob/master/lib/facter/osfamily.rb#L19-L20
