### PR TITLE
The --no-custom-installers ption is deprecated in favor of --no-plugins

### DIFF
--- a/templates/exec.erb
+++ b/templates/exec.erb
@@ -1,7 +1,7 @@
 <%= command -%>
 <% if prefer_source %> --prefer-source<% end -%>
 <% if prefer_dist %> --prefer-dist<% end -%>
-<% unless custom_installers %> --no-custom-installers<% end -%>
+<% unless custom_installers %> --no-plugins<% end -%>
 <% unless scripts %> --no-scripts<% end -%>
 <% unless interaction %> --no-interaction<% end -%>
 <% if dev %> --dev<% end -%>


### PR DESCRIPTION
The `--no-custom-installers` ption is deprecated in favor of `--no-plugins`. This is just to cleanup warnings and prepare for the possibility of removing the previous `--no-custom-installers` option. See https://github.com/composer/composer/pull/2179.
