### PR TITLE
Deprecated variable calls

### DIFF
--- a/templates/exec.erb
+++ b/templates/exec.erb
@@ -1,15 +1,15 @@
-<%= command -%>
-<% if prefer_source %> --prefer-source<% end -%>
-<% if prefer_dist %> --prefer-dist<% end -%>
-<% unless custom_installers %> --no-plugins<% end -%>
-<% unless scripts %> --no-scripts<% end -%>
-<% unless interaction %> --no-interaction<% end -%>
-<% if dev %> --dev<% end -%>
-<% if verbose %> -v<% end -%>
-<% if dry_run %> --dry-run<% end -%>
-<% if cmd == 'update' -%>
-    <%- if packages -%>
-        <%- packages.each do |package| -%>
+<%= @command -%>
+<% if @prefer_source %> --prefer-source<% end -%>
+<% if @prefer_dist %> --prefer-dist<% end -%>
+<% unless @custom_installers %> --no-plugins<% end -%>
+<% unless @scripts %> --no-scripts<% end -%>
+<% unless @interaction %> --no-interaction<% end -%>
+<% if @dev %> --dev<% end -%>
+<% if @verbose %> -v<% end -%>
+<% if @dry_run %> --dry-run<% end -%>
+<% if @cmd == 'update' -%>
+    <%- if @packages -%>
+        <%- @packages.each do |package| -%>
             <%= ' ' + package -%>
         <%- end -%>
     <%- end -%>


### PR DESCRIPTION
Doing a simple exec produces the following warnings:

Warning: Variable access via 'command' is deprecated. Use '@command' instead. template[/etc/puppet/modules/composer/templates/exec.erb]:1
   (at /etc/puppet/modules/composer/templates/exec.erb:1:in `result')
Warning: Variable access via 'prefer_source' is deprecated. Use '@prefer_source' instead. template[/etc/puppet/modules/composer/templates/exec.erb]:2
   (at /etc/puppet/modules/composer/templates/exec.erb:2:in`result')
Warning: Variable access via 'prefer_dist' is deprecated. Use '@prefer_dist' instead. template[/etc/puppet/modules/composer/templates/exec.erb]:3
   (at /etc/puppet/modules/composer/templates/exec.erb:3:in `result')
Warning: Variable access via 'custom_installers' is deprecated. Use '@custom_installers' instead. template[/etc/puppet/modules/composer/templates/exec.erb]:4
   (at /etc/puppet/modules/composer/templates/exec.erb:4:in`result')
Warning: Variable access via 'scripts' is deprecated. Use '@scripts' instead. template[/etc/puppet/modules/composer/templates/exec.erb]:5
   (at /etc/puppet/modules/composer/templates/exec.erb:5:in `result')
Warning: Variable access via 'interaction' is deprecated. Use '@interaction' instead. template[/etc/puppet/modules/composer/templates/exec.erb]:6
   (at /etc/puppet/modules/composer/templates/exec.erb:6:in`result')
Warning: Variable access via 'dev' is deprecated. Use '@dev' instead. template[/etc/puppet/modules/composer/templates/exec.erb]:7
   (at /etc/puppet/modules/composer/templates/exec.erb:7:in `result')
Warning: Variable access via 'verbose' is deprecated. Use '@verbose' instead. template[/etc/puppet/modules/composer/templates/exec.erb]:8
   (at /etc/puppet/modules/composer/templates/exec.erb:8:in`result')
Warning: Variable access via 'dry_run' is deprecated. Use '@dry_run' instead. template[/etc/puppet/modules/composer/templates/exec.erb]:9
   (at /etc/puppet/modules/composer/templates/exec.erb:9:in `result')
Warning: Variable access via 'cmd' is deprecated. Use '@cmd' instead. template[/etc/puppet/modules/composer/templates/exec.erb]:10
   (at /etc/puppet/modules/composer/templates/exec.erb:10:in`result')
Warning: Variable access via 'packages' is deprecated. Use '@packages' instead. template[/etc/puppet/modules/composer/templates/exec.erb]:11
   (at /etc/puppet/modules/composer/templates/exec.erb:11:in `result')
Warning: Variable access via 'packages' is deprecated. Use '@packages' instead. template[/etc/puppet/modules/composer/templates/exec.erb]:12
   (at /etc/puppet/modules/composer/templates/exec.erb:12:in`result')
