### PR TITLE
Add parameter 'php_bin' to override name or path of php binary

### DIFF
--- a/manifests/exec.pp
+++ b/manifests/exec.pp
@@ -44,7 +44,7 @@ define composer::exec (
     fail('Only one of \$prefer_source or \$prefer_dist can be true.')
   }
 
-  $command = "php ${composer::target_dir}/${composer::composer_file} ${cmd}"
+  $command = "${composer::php_bin} ${composer::target_dir}/${composer::composer_file} ${cmd}"
 
   exec { "composer_update_${title}":
     command     => template('composer/exec.erb'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,10 @@
 #   from our composer::params class which derives from our own $composer_home
 #   fact. The fact returns the current users $HOME environment variable.
 #
+# [*php_bin*]
+#   The name or path of the php binary to override the default set in the
+#   composer::params class.
+#
 # === Authors
 #
 # Thomas Ploch <profiploch@gmail.com>
@@ -52,6 +56,7 @@ class composer(
   $curl_package    = $composer::params::curl_package,
   $wget_package    = $composer::params::wget_package,
   $composer_home   = $composer::params::composer_home,
+  $php_bin         = $composer::params::php_bin,
   $suhosin_enabled = $composer::params::suhosin_enabled
 ) inherits composer::params {
 
@@ -64,7 +69,7 @@ class composer(
   # download composer
   case $download_method {
     'curl': {
-      $download_command = 'curl -s http://getcomposer.org/installer | php'
+      $download_command = "curl -s http://getcomposer.org/installer | ${composer::php_bin}"
       $download_require = $suhosin_enabled ? {
         true  => [ Package['curl', $php_package], Augeas['allow_url_fopen', 'whitelist_phar'] ],
         false => [ Package['curl', $php_package] ]

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,6 +24,7 @@ class composer::params {
       $php_package     = 'php5-cli'
       $curl_package    = 'curl'
       $wget_package    = 'wget'
+      $php_bin         = 'php'
       $suhosin_enabled = true
     }
     'RedHat': {
@@ -35,6 +36,7 @@ class composer::params {
       $php_package     = 'php-cli'
       $curl_package    = 'curl'
       $wget_package    = 'wget'
+      $php_bin         = 'php'
       $suhosin_enabled = true
     }
     default: {

--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -59,7 +59,7 @@ define composer::project(
   }
 
   $exec_name    = "composer_create_project_${title}"
-  $base_command = "php ${composer::target_dir}/${composer::composer_file} --stability=${stability}"
+  $base_command = "${composer::php_bin} ${composer::target_dir}/${composer::composer_file} --stability=${stability}"
   $end_command  = "${project_name} ${target_dir}"
 
   $dev_arg = $dev ? {

--- a/spec/classes/composer_spec.rb
+++ b/spec/classes/composer_spec.rb
@@ -71,6 +71,7 @@ describe 'composer' do
           :php_package     => 'php8-cli',
           :composer_file   => 'compozah',
           :curl_package    => 'kerl',
+          :php_bin         => 'pehpe',
           :suhosin_enabled => false,
         } }
 


### PR DESCRIPTION
In some cases I want (need) to be able to set the php binary (respectively the path of the binary) used for executing composer.

**Case 1)**
Multiple versions of PHP on one environment.

Example:

```
class { 'composer':
  target_dir      => '/usr/local/bin',
  composer_file   => 'composer',
  php_bin         => '/usr/local/bin/php5',
}
```

**Case 2)**
If composer is used with apc.enable_cli=1, it results in an error, see these resources:
https://github.com/composer/composer/issues/264
http://chapter31.com/2013/06/03/php-composer-error-cannot-redeclare-class/

By setting `php_bin=php -d "apc.enable_cli=0"` I can get around the error without globally disabling apc in cli mode.

Example:

```
class { 'composer':
  target_dir      => '/usr/local/bin',
  composer_file   => 'composer',
  php_bin         => 'php -d "apc.enable_cli=0"',
}
```
