### PR TITLE
Now also supports Amazon Linux (RedHat)

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -115,7 +115,7 @@ class composer(
   }
 
   if $suhosin_enabled {
-    case $::osfamily {
+    case $family {
 
       'Redhat','Centos': {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,7 +14,14 @@
 class composer::params {
   $composer_home = $::composer_home
 
-  case $::osfamily {
+  # Support Amazon Linux which is supported by RedHat family
+  if $::osfamily == 'Linux' and $::operatingsystem == 'Amazon' {
+    $family = 'RedHat'
+  } else {
+    $family = $::osfamily
+  }
+
+  case $family {
     'Debian': {
       $target_dir      = '/usr/local/bin'
       $composer_file   = 'composer'
@@ -27,7 +34,7 @@ class composer::params {
       $php_bin         = 'php'
       $suhosin_enabled = true
     }
-    'RedHat': {
+    'RedHat', 'Centos': {
       $target_dir      = '/usr/local/bin'
       $composer_file   = 'composer'
       $download_method = 'curl'
@@ -40,7 +47,7 @@ class composer::params {
       $suhosin_enabled = true
     }
     default: {
-      fail("Unsupported platform: ${::osfamily}")
+      fail("Unsupported platform: ${family}")
     }
   }
 }

--- a/spec/classes/composer_params_spec.rb
+++ b/spec/classes/composer_params_spec.rb
@@ -1,10 +1,11 @@
 require 'spec_helper'
 
 describe 'composer::params' do
-  ['RedHat', 'Debian'].each do |osfamily|
+  ['RedHat', 'Debian', 'Linux'].each do |osfamily|
     context "on #{osfamily} operating system family" do
       let(:facts) { {
-        :osfamily => osfamily,
+        :osfamily        => osfamily,
+        :operatingsystem => 'Amazon',
       } }
 
       it { should compile }

--- a/spec/classes/composer_spec.rb
+++ b/spec/classes/composer_spec.rb
@@ -1,9 +1,13 @@
 require 'spec_helper'
 
 describe 'composer' do
-  ['RedHat', 'Debian'].each do |osfamily|
+  ['RedHat', 'Debian', 'Linux'].each do |osfamily|
     case osfamily
     when 'RedHat'
+      php_package = 'php-cli'
+      php_context = '/files/etc/php.ini/PHP'
+      suhosin_context = '/files/etc/suhosin.ini/suhosin'
+    when 'Linux'
       php_package = 'php-cli'
       php_context = '/files/etc/php.ini/PHP'
       suhosin_context = '/files/etc/suhosin.ini/suhosin'
@@ -19,7 +23,8 @@ describe 'composer' do
 
     context "on #{osfamily} operating system family" do
       let(:facts) { {
-          :osfamily => osfamily,
+          :osfamily        => osfamily,
+          :operatingsystem => 'Amazon'
       } }
 
       it { should contain_class('composer::params') }
@@ -63,6 +68,17 @@ describe 'composer' do
             :mode   => '0755',
           })
         }
+      end
+
+      context "on invalid operating system family" do
+        let(:facts) { {
+          :osfamily        => 'Invalid',
+          :operatingsystem => 'Amazon'
+        } }
+
+        it 'should not compile' do
+          expect { should compile }.to raise_error(/Unsupported platform: Invalid/)
+        end
       end
 
       context 'with custom parameters' do


### PR DESCRIPTION
A new variable `$family` has bee introduced that will be set to
`RedHat` when `$::osfamily` is `'Linux'` and `$::operatingsystem`
is `'Amazon'`.

Fixes #25
