### PR TITLE
Pr require command

### DIFF
--- a/manifests/exec.pp
+++ b/manifests/exec.pp
@@ -13,20 +13,25 @@
 define composer::exec (
   $cmd,
   $cwd,
-  $packages          = [],
-  $prefer_source     = false,
-  $prefer_dist       = false,
-  $dry_run           = false,
-  $custom_installers = false,
-  $scripts           = false,
-  $optimize          = false,
-  $interaction       = false,
-  $dev               = false,
-  $logoutput         = false,
-  $verbose           = false,
-  $refreshonly       = false,
-  $user              = undef,
+  $packages                 = [],
+  $prefer_source            = false,
+  $prefer_dist              = false,
+  $dry_run                  = false,
+  $custom_installers        = false,
+  $scripts                  = false,
+  $optimize                 = false,
+  $interaction              = false,
+  $dev                      = false,
+  $no_update                = false, 
+  $no_progress              = false,
+  $update_with_dependencies = false,
+  $logoutput                = false,
+  $verbose                  = false,
+  $refreshonly              = false,
+  $user                     = undef,
+  $global                   = false,
 ) {
+
   require composer
   require git
 
@@ -36,20 +41,24 @@ define composer::exec (
     user        => $user,
   }
 
-  if $cmd != 'install' and $cmd != 'update' {
-    fail("Only types 'install' and 'update' are allowed, ${cmd} given")
+  if $cmd != 'install' and $cmd != 'update' and $cmd != 'require' {
+    fail("Only types 'install', 'update' and 'require'' are allowed, ${cmd} given")
   }
 
   if $prefer_source and $prefer_dist {
     fail('Only one of \$prefer_source or \$prefer_dist can be true.')
   }
 
-  $command = "${composer::php_bin} ${composer::target_dir}/${composer::composer_file} ${cmd}"
+  $command = $global ? {
+    true  => "${composer::php_bin} ${composer::target_dir}/${composer::composer_file} global ${cmd}",
+    false => "${composer::php_bin} ${composer::target_dir}/${composer::composer_file} ${cmd}",
+  }
 
-  exec { "composer_update_${title}":
-    command     => template('composer/exec.erb'),
+  exec { "composer_${cmd}_${title}":
+    command     => template("composer/${cmd}.erb"),
     cwd         => $cwd,
     logoutput   => $logoutput,
-    refreshonly => $refreshonly
+    refreshonly => $refreshonly,
+    user        => $user,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,6 +59,7 @@ class composer(
   $php_bin         = $composer::params::php_bin,
   $suhosin_enabled = $composer::params::suhosin_enabled,
   $projects        = hiera_hash('composer::projects', {}),
+  $execs           = hiera_hash('composer::execs', {}),
 ) inherits composer::params {
 
   Exec { path => "/bin:/usr/bin/:/sbin:/usr/sbin:${target_dir}" }
@@ -154,9 +155,10 @@ class composer(
     }
   }
 
-  if $projects {
+  if $projects or $execs{
     class {'composer::project_factory' :
       projects => $projects,
+      execs    => $execs,
     }
   }
 }

--- a/manifests/project_factory.pp
+++ b/manifests/project_factory.pp
@@ -8,9 +8,14 @@
 #
 class composer::project_factory (
   $projects = hiera_hash('composer::project_factory::projects', {}),
+  $execs    = hiera_hash('composer::project_factory::execs', {}),
 ) {
 
   if $projects {
     create_resources('composer::project', $projects) 
+  }
+
+  if $execs {
+    create_resources('composer::exec', $execs) 
   }
 }

--- a/spec/defines/composer_exec_spec.rb
+++ b/spec/defines/composer_exec_spec.rb
@@ -19,7 +19,7 @@ describe 'composer::exec' do
         } }
 
         it {
-          should contain_exec('composer_update_myproject').with({
+          should contain_exec('composer_install_myproject').with({
             :command       => %r{php /usr/local/bin/composer install --no-plugins --no-scripts --no-interaction},
             :cwd       => '/my/awesome/project',
             :user      => 'linus',
@@ -42,7 +42,28 @@ describe 'composer::exec' do
 
         it {
           should contain_exec('composer_update_yourpr0ject').without_user.with({
-            :command   => %r{php /usr/local/bin/composer update --no-plugins --no-scripts --no-interaction             package1             packageinf},
+            :command   => %r{php /usr/local/bin/composer update --no-plugins --no-scripts --no-interaction         package1         packageinf},
+            :cwd       => '/just/in/time',
+            :logoutput => true,
+          })
+        }
+      end
+
+      context 'using require command' do
+        it { should contain_class('git') }
+        it { should contain_class('composer') }
+
+        let(:title) { 'yourpr0ject' }
+        let(:params) { {
+          :cmd       => 'require',
+          :cwd       => '/just/in/time',
+          :packages  => ['package1', 'packageinf'],
+          :logoutput => true,
+        } }
+
+        it {
+          should contain_exec('composer_require_yourpr0ject').without_user.with({
+            :command   => %r{php /usr/local/bin/composer require package1 packageinf},
             :cwd       => '/just/in/time',
             :logoutput => true,
           })

--- a/templates/install.erb
+++ b/templates/install.erb
@@ -7,11 +7,3 @@
 <% if @dev %> --dev<% end -%>
 <% if @verbose %> -v<% end -%>
 <% if @dry_run %> --dry-run<% end -%>
-<% if @cmd == 'update' -%>
-    <%- if @packages -%>
-        <%- @packages.each do |package| -%>
-            <%= ' ' + package -%>
-        <%- end -%>
-    <%- end -%>
-<% end -%>
-

--- a/templates/require.erb
+++ b/templates/require.erb
@@ -1,0 +1,10 @@
+<%= @command -%>
+<% if @prefer_source %> --prefer-source<% end -%>
+<% if @prefer_dist %> --prefer-dist<% end -%>
+<% if @dev %> --dev<% end -%>
+<% if @no_update %> --no-update<% end -%>
+<% if @no_progress %> --no-progress<% end -%>
+<% if @update_with_dependencies %> --update-with-dependencies<% end -%>
+<%- @packages.each do |package| -%>
+<%= ' ' + package -%>
+<%- end -%>

--- a/templates/update.erb
+++ b/templates/update.erb
@@ -1,0 +1,14 @@
+<%= @command -%>
+<% if @prefer_source %> --prefer-source<% end -%>
+<% if @prefer_dist %> --prefer-dist<% end -%>
+<% unless @custom_installers %> --no-plugins<% end -%>
+<% unless @scripts %> --no-scripts<% end -%>
+<% unless @interaction %> --no-interaction<% end -%>
+<% if @dev %> --dev<% end -%>
+<% if @verbose %> -v<% end -%>
+<% if @dry_run %> --dry-run<% end -%>
+<%- if @packages -%>
+    <%- @packages.each do |package| -%>
+        <%= ' ' + package -%>
+    <%- end -%>
+<%- end -%>


### PR DESCRIPTION
This add support for 'require' command and add exec to the factory so we could do something like this from hiera .yaml file

composer::projects:
  devlib/devlib:
    project_name: devlib/devlib
    target_dir: '/home/user/my-libs/devlib/devlib/'
composer::execs:
  phpqa:
    user: vagrant
    cmd: 'require'
    cwd: '/home/vagrant/.composer/'
    prefer_dist: true
    packages: 
      - 'phpunit/phpunit=3.7._'
      - 'codesniffer/codesniffer=3.7._'
      - 'cyclomatic-complexity=3.7.*'
  another-load-of-libraries:
    user: vagrant
    cmd: 'update'
    cwd: '/home/vagrant/.composer/'
    prefer_dist: true
    packages: 
      - 'whatever-1
      - 'whatever-2'
      - 'whatever-3'
