### PR TITLE
Added "cwd" option to the exec when the project is created

### DIFF
--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -103,5 +103,6 @@ define composer::project(
     tries   => $tries,
     timeout => $timeout,
     creates => $target_dir,
+    cwd     => $working_dir
   }
 }

--- a/spec/defines/composer_project_spec.rb
+++ b/spec/defines/composer_project_spec.rb
@@ -56,6 +56,7 @@ describe 'composer::project' do
             :timeout => 600,
             :creates => '/my/mediocre/project',
             :user    => 'mrploch',
+            :cwd     => '/my/working-dir',
           })
         }
       end


### PR DESCRIPTION
When using this module it didn't worked for me until I added this option, for example:

```
composer::project { 'satis':
  project_name   => 'composer/satis',
  target_dir => "$home/satis",
  version=> '1.0.0-alpha1',
  stability  => 'dev',
  keep_vcs   => "$home/satis",
  dev=> false,
  working_dir=> $home,
  user   => 'satis',
}
```

Failed miserably with permission errors.
