### PR TITLE
Use TLS (HTTPS) to retrieve composer.phar

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -86,7 +86,7 @@ class composer(
   # download composer
   case $download_method {
     'curl': {
-      $download_command = "curl -s http://getcomposer.org/installer | ${composer::php_bin}"
+      $download_command = "curl -s https://getcomposer.org/installer | ${composer::php_bin}"
       $download_require = $suhosin_enabled ? {
         false    => [ Package['curl', $php_package] ],
         default  => [ Package['curl', $php_package], Augeas['allow_url_fopen', 'whitelist_phar'] ],
@@ -94,7 +94,7 @@ class composer(
       $method_package = $curl_package
     }
     'wget': {
-      $download_command = 'wget http://getcomposer.org/composer.phar -O composer.phar'
+      $download_command = 'wget https://getcomposer.org/composer.phar -O composer.phar'
       $download_require = $suhosin_enabled ? {
         false   => [ Package['wget', $php_package] ],
         default => [ Package['wget', $php_package], Augeas['allow_url_fopen', 'whitelist_phar'] ],

--- a/spec/classes/composer_spec.rb
+++ b/spec/classes/composer_spec.rb
@@ -31,7 +31,7 @@ describe 'composer' do
 
       it {
         should contain_exec('download_composer').with({
-          :command     => 'curl -s http://getcomposer.org/installer | php',
+          :command     => 'curl -s https://getcomposer.org/installer | php',
           :cwd         => '/tmp',
           :creates     => '/tmp/composer.phar',
           :logoutput   => false,


### PR DESCRIPTION
Set the download URL to use HTTPS, which provides some guarantee as to
the authenticity of the file being downloaded.

HTTPS is supported by getcomposer.org:

```
» curl -I -XHEAD https://getcomposer.org/ 2>/dev/null | head -n 1
» HTTP/1.1 200 OK
```
