### PR TITLE
Add an option to setup github token.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ class { 'composer':
     php_bin         => 'php', # could also i.e. be 'php -d "apc.enable_cli=0"' for more fine grained control
     suhosin_enabled => true,
     auto_update     => false, # Set to true to automatically update composer to the latest version
+    github_token    => '1234567890abcdefgh',
 }
 ```
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,6 +66,7 @@ class composer(
   $suhosin_enabled = $composer::params::suhosin_enabled,
   $auto_update     = $composer::params::auto_update,
   $projects        = hiera_hash('composer::execs', {}),
+  $github_token    = undef,
 ) inherits ::composer::params {
 
   require ::stdlib
@@ -174,6 +175,19 @@ class composer(
           require     => Package[$php_package],
         }
       }
+    }
+  }
+
+
+  if $github_token {
+    Exec {
+      environment => "COMPOSER_HOME=${composer_home}",
+    }
+    exec { 'setup_github_token':
+      command   => "${target_dir}/${composer_file} config -g github-oauth.github.com ${github_token}",
+      cwd       => $tmp_path,
+      require   => File["${target_dir}/${composer_file}"],
+      unless    => "${target_dir}/${composer_file} config -g github-oauth.github.com|grep ${github_token}",
     }
   }
 

--- a/spec/classes/composer_spec.rb
+++ b/spec/classes/composer_spec.rb
@@ -68,6 +68,8 @@ describe 'composer' do
             :mode   => '0755',
           })
         }
+
+        it { should_not contain_exec('setup_github_token') }
       end
 
       context "on invalid operating system family" do
@@ -89,6 +91,7 @@ describe 'composer' do
           :curl_package    => 'kerl',
           :php_bin         => 'pehpe',
           :suhosin_enabled => false,
+          :github_token    => 'my_token',
         } }
 
         it 'should compile' do
@@ -110,6 +113,13 @@ describe 'composer' do
         it { should_not contain_augeas('whitelist_phar') }
         it { should_not contain_augeas('allow_url_fopen') }
 
+        it {
+          should contain_exec('setup_github_token').with({
+            :command => "/you_sir/lowcal/been/compozah config -g github-oauth.github.com my_token",
+            :cwd     => '/tmp',
+            :unless  => "/you_sir/lowcal/been/compozah config -g github-oauth.github.com|grep my_token",
+          })
+        }
       end
 
       context 'when receiving a projects hash' do


### PR DESCRIPTION
When downloading packages from github, API calls limited for anonymouse
user. Composer will prompt for github username and passoword to fetch
the token. By setting up Github token, one can increase the limits of
the API calls.
