### PR TITLE
Fix param defaults for newer Ubuntu releases

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,7 +33,14 @@ class composer::params {
       $curl_package    = 'curl'
       $wget_package    = 'wget'
       $php_bin         = 'php'
-      $suhosin_enabled = true
+      case $::operatingsystem {
+        'Ubuntu': {
+          $suhosin_enabled = versioncmp($::operatingsystemmajrelease, '12.04') <= 0
+        }
+        default: {
+          $suhosin_enabled = true
+        }
+      }
     }
     'RedHat', 'Centos': {
       $target_dir      = '/usr/local/bin'

--- a/spec/classes/composer_spec.rb
+++ b/spec/classes/composer_spec.rb
@@ -1,90 +1,150 @@
 require 'spec_helper'
 
 describe 'composer' do
-  ['RedHat', 'Debian', 'Linux'].each do |osfamily|
-    case osfamily
-    when 'RedHat'
-      php_package = 'php-cli'
-      php_context = '/files/etc/php.ini/PHP'
-      suhosin_context = '/files/etc/suhosin.ini/suhosin'
-    when 'Linux'
-      php_package = 'php-cli'
-      php_context = '/files/etc/php.ini/PHP'
-      suhosin_context = '/files/etc/suhosin.ini/suhosin'
-    when 'Debian'
-      php_package = 'php5-cli'
-      php_context = '/files/etc/php5/cli/php.ini/PHP'
-      suhosin_context = '/files/etc/php5/conf.d/suhosin.ini/suhosin'
-    else
-      php_package = 'php-cli'
-      php_context = '/files/etc/php.ini/PHP'
-      suhosin_context = '/files/etc/suhosin.ini/suhosin'
+
+  shared_examples 'a composer module' do |params, ctx|
+    p = {
+      :php_package     => 'php-cli',
+      :php_bin         => 'php',
+      :curl_package    => 'curl',
+      :target_dir      => '/usr/local/bin',
+      :composer_file   => 'composer',
+      :suhosin_enabled => true,
+    }
+
+    p.merge!(params) if params
+
+    c = {
+      :php_context     => '/files/etc/php.ini/PHP',
+      :suhosin_context => '/files/etc/suhosin.ini/suhosin',
+    }
+
+    c.merge!(ctx) if ctx
+
+    composer_path = "#{p[:target_dir]}/#{p[:composer_file]}"
+
+    it 'should compile' do
+      compile
     end
 
-    context "on #{osfamily} operating system family" do
-      let(:facts) { {
-          :osfamily        => osfamily,
-          :operatingsystem => 'Amazon'
-      } }
+    it { should contain_class('composer::params') }
 
-      it { should contain_class('composer::params') }
+    it {
+      should contain_exec('download_composer').with({
+        :command     => "curl -s https://getcomposer.org/installer | #{p[:php_bin]}",
+        :cwd         => '/tmp',
+        :creates     => '/tmp/composer.phar',
+        :logoutput   => false,
+      })
+    }
 
-      it {
-        should contain_exec('download_composer').with({
-          :command     => 'curl -s https://getcomposer.org/installer | php',
-          :cwd         => '/tmp',
-          :creates     => '/tmp/composer.phar',
-          :logoutput   => false,
-        })
-      }
+    it { should contain_package(p[:php_package]).with_ensure('present') }
+    it { should contain_package(p[:curl_package]).with_ensure('present') }
+    it { should contain_file(p[:target_dir]).with_ensure('directory') }
 
+    it {
+      should contain_file(composer_path).with({
+        :source => 'present',
+        :source => '/tmp/composer.phar',
+        :mode   => '0755',
+      })
+    }
+
+    if p[:suhosin_enabled] then
       it {
         should contain_augeas('whitelist_phar').with({
-          :context     => suhosin_context,
+          :context     => c[:suhosin_context],
           :changes     => 'set suhosin.executor.include.whitelist phar',
         })
       }
 
       it {
         should contain_augeas('allow_url_fopen').with({
-          :context    => php_context,
+          :context    => c[:php_context],
           :changes    => 'set allow_url_fopen On',
         })
       }
+    else
+      it { should_not contain_augeas('whitelist_phar') }
+      it { should_not contain_augeas('allow_url_fopen') }
+    end
 
-      context 'with default parameters' do
-        it 'should compile' do
-          compile
-        end
+    if p.include? :github_token then
+      it_behaves_like 'it sets a github token', composer_path, p[:github_token]
+    end
+  end
 
-        it { should contain_package(php_package).with_ensure('present') }
-        it { should contain_package('curl').with_ensure('present') }
-        it { should contain_file('/usr/local/bin').with_ensure('directory') }
+  shared_examples 'it sets a github token' do |path, token|
+    it {
+      should contain_exec('setup_github_token').with({
+        :command => "#{path} config -g github-oauth.github.com #{token}",
+        :cwd     => '/tmp',
+        :unless  => "#{path} config -g github-oauth.github.com|grep #{token}",
+      })
+    }
+  end
 
-        it {
-          should contain_file('/usr/local/bin/composer').with({
-            :source => 'present',
-            :source => '/tmp/composer.phar',
-            :mode   => '0755',
-          })
-        }
+  shared_examples 'a composer module with projects' do |params, ctx|
+    p = {
+      :projects => {
+          'pkg1' => { 'project_name' => 'pkg1', 'target_dir' => '/home/pkg1' },
+          'pkg2' => { 'project_name' => 'pkg2', 'target_dir' => '/home/pkg2' },
+      }
+    }
 
-        it { should_not contain_exec('setup_github_token') }
+    p.merge!(params)
+
+    let(:params) { p }
+
+    it_behaves_like 'a composer module', p, ctx
+
+    it {
+      should contain_composer__project('pkg1').with({
+        'project_name' => 'pkg1',
+        'target_dir'   => '/home/pkg1',
+      })
+    }
+
+    it {
+      should contain_composer__project('pkg2').with({
+        'project_name' => 'pkg2',
+        'target_dir'   => '/home/pkg2',
+      })
+    }
+
+    it { should have_composer__project_resource_count(2) }
+  end
+
+  ['RedHat', 'Debian', 'Linux'].each do |osfamily|
+    case osfamily
+    when 'RedHat'
+      params = {}
+      ctx = {
+        :php_context     => '/files/etc/php.ini/PHP',
+        :suhosin_context => '/files/etc/suhosin.ini/suhosin',
+      }
+    when 'Debian'
+      params = {
+        :php_package => 'php5-cli'
+      }
+      ctx = {
+        :php_context     => '/files/etc/php5/cli/php.ini/PHP',
+        :suhosin_context => '/files/etc/php5/conf.d/suhosin.ini/suhosin',
+      }
+    when 'Linux'
+      params = {}
+      ctx = {}
+    end
+    context "for osfamily #{osfamily}" do
+      let(:facts) { {
+        :osfamily        => osfamily,
+        :operatingsystem => 'Amazon'
+      } }
+      context 'with defaults' do
+        it_behaves_like 'a composer module', params, ctx
       end
-
-      context "on invalid operating system family" do
-        let(:facts) { {
-          :osfamily        => 'Invalid',
-          :operatingsystem => 'Amazon'
-        } }
-
-        it 'should not compile' do
-          expect { should compile }.to raise_error(/Unsupported platform: Invalid/)
-        end
-      end
-
       context 'with custom parameters' do
-        let(:params) { {
+        custom_params = {
           :target_dir      => '/you_sir/lowcal/been',
           :php_package     => 'php8-cli',
           :composer_file   => 'compozah',
@@ -92,58 +152,24 @@ describe 'composer' do
           :php_bin         => 'pehpe',
           :suhosin_enabled => false,
           :github_token    => 'my_token',
-        } }
-
-        it 'should compile' do
-          compile
-        end
-
-        it { should contain_package('php8-cli').with_ensure('present') }
-        it { should contain_package('kerl').with_ensure('present') }
-        it { should contain_file('/you_sir/lowcal/been').with_ensure('directory') }
-
-        it {
-          should contain_file('/you_sir/lowcal/been/compozah').with({
-            :source => 'present',
-            :source => '/tmp/composer.phar',
-            :mode   => '0755',
-          })
         }
-
-        it { should_not contain_augeas('whitelist_phar') }
-        it { should_not contain_augeas('allow_url_fopen') }
-
-        it {
-          should contain_exec('setup_github_token').with({
-            :command => "/you_sir/lowcal/been/compozah config -g github-oauth.github.com my_token",
-            :cwd     => '/tmp',
-            :unless  => "/you_sir/lowcal/been/compozah config -g github-oauth.github.com|grep my_token",
-          })
-        }
+        let(:params) { custom_params }
+        it_behaves_like 'a composer module', custom_params, ctx
       end
-
-      context 'when receiving a projects hash' do
-        let(:params) { {
-          :projects        => { 'library1' => { 'project_name' => 'lib1', 'target_dir' => '/home/lib1' }, 'library2' => { 'project_name' => 'lib2', 'target_dir' => '/home/lib2' } }
-        } }
-
-        it {
-          should contain_composer__project('library1').with({
-            'project_name' => 'lib1',
-            'target_dir'   => '/home/lib1',
-          })
-        }
-
-        it {
-          should contain_composer__project('library2').with({
-            'project_name' => 'lib2',
-            'target_dir'   => '/home/lib2',
-          })
-        }
-
-        it { should have_composer__project_resource_count(2) }
-
+      context 'with projects' do
+        it_behaves_like 'a composer module with projects', params, ctx
       end
+    end
+  end
+
+  context "for invalid operating system family" do
+    let(:facts) { {
+      :osfamily        => 'Invalid',
+      :operatingsystem => 'Amazon'
+    } }
+
+    it 'should not compile' do
+      expect { should compile }.to raise_error(/Unsupported platform: Invalid/)
     end
   end
 end


### PR DESCRIPTION
This PR disables suhosin by default for Ubuntu releases > 12.04 (precise), allowing developers to use `include composer` without errors.
