### PR TITLE
Integrate Beaker for Acceptance Testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 spec/fixtures/modules/*
+spec/fixtures/puppet/common.yaml
 .bundle/
 vendor/
 Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,37 @@
 language: ruby
 rvm:
+  - 2.1.4
+  - 2.0.0
   - 1.9.3
   - 1.8.7
 before_script:
 after_script:
 script: "bundle exec rake spec"
+bundler_args: --without acceptance
 env:
   - PUPPET_VERSION=2.7.25
   - PUPPET_VERSION=3.1.1
   - PUPPET_VERSION=3.2.4
   - PUPPET_VERSION=3.3.2
   - PUPPET_VERSION=3.4.3
+  - PUPPET_VERSION=3.7.3 FUTURE_PARSER="yes"
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+  exclude:
+    - rvm: 2.0.0
+      env: PUPPET_VERSION=2.7.25
+    - rvm: 2.0.0
+      env: PUPPET_VERSION=3.1.1
+    - rvm: 2.1.4
+      env: PUPPET_VERSION=2.7.25
+    - rvm: 2.1.4
+      env: PUPPET_VERSION=3.1.1
+    - rvm: 2.1.4
+      env: PUPPET_VERSION=3.2.4
+    - rvm: 2.1.4
+      env: PUPPET_VERSION=3.3.2
+  fast_finish: true
 notifications:
   email: false
 branches:

--- a/Gemfile
+++ b/Gemfile
@@ -16,3 +16,8 @@ gem 'mocha'
 gem 'puppet-lint'
 gem 'hiera'
 gem 'hiera-puppet'
+
+group :acceptance do
+  gem 'beaker'
+  gem 'beaker-rspec'
+end

--- a/README.md
+++ b/README.md
@@ -181,6 +181,30 @@ To bring up the development VM you can run `rake vagrant:up`. This Rake task run
 
 The VM will get the `spec/fixtures/manifests/vagrant.pp` file applied to the node. This currently creates a Silex project at `/tmp/silex` when the VM starts up. You can modify this manifest to your liking.
 
+### Acceptance Tests
+
+Acceptance tests are written using [Beaker](https://github.com/puppetlabs/beaker/wiki).
+
+To run the beaker tests via rake, you can simply run `rake beaker`.
+
+To use something other than the default beaker node, try the following:
+
+```
+BEAKER_set=ubuntu-server-1404-x64 rake beaker
+```
+
+To use beaker without rake, simply run `rspec spec/acceptance`.
+
+**Beaker + Hiera**
+
+When running acceptance tests, you may hit GitHub rate limits much faster than you would otherwise. To ensure your tests do not fail arbitrarily, you can add your GitHub auth token via hiera.
+
+Create a hiera config at `spec/fixtures/puppet/common.yaml`, that looks like this:
+
+```yaml
+composer::github_token: 'my_github_auth_token'
+```
+
 Happy testing!
 
 ## Contributing

--- a/spec/acceptance/composer_project_spec.rb
+++ b/spec/acceptance/composer_project_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper_acceptance'
+
+describe 'composer::project class' do
+  describe 'running puppet code' do
+    # Using puppet_apply as a helper
+    it 'should work with no errors' do
+      pp = <<-EOS
+        include composer
+        composer::project {'silex':
+          project_name => 'fabpot/silex-skeleton',
+          target_dir   => '/tmp/silex',
+        }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+  end
+
+  describe file('/tmp/silex/composer.json') do
+    it { should be_file }
+  end
+end

--- a/spec/acceptance/nodesets/centos-65-x64.yml
+++ b/spec/acceptance/nodesets/centos-65-x64.yml
@@ -1,0 +1,11 @@
+HOSTS:
+  centos-65-x64:
+    roles:
+      - master
+    platform: el-6-x86_64
+    box: puppetlabs/centos-6.5-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-6.5-64-nocm
+    hypervisor: vagrant
+CONFIG:
+  log_level: verbose
+  type: foss

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,11 @@
+HOSTS:
+  ubuntu-server-1204-x64:
+    roles:
+      - master
+    platform: ubuntu-12.04-amd64
+    box: puppetlabs/ubuntu-12.04-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/ubuntu-12.04-64-nocm
+    hypervisor: vagrant
+CONFIG:
+  log_level: verbose
+  type: foss

--- a/spec/acceptance/nodesets/ubuntu-server-1404-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-server-1404-x64.yml
@@ -1,0 +1,11 @@
+HOSTS:
+  ubuntu-server-1404-x64:
+    roles:
+      - master
+    platform: ubuntu-14.04-amd64
+    box: puppetlabs/ubuntu-14.04-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/ubuntu-14.04-64-nocm
+    hypervisor: vagrant
+CONFIG:
+  log_level: verbose
+  type: foss

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,37 @@
+require 'beaker-rspec/spec_helper'
+require 'beaker-rspec/helpers/serverspec'
+
+unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
+  if hosts.first.is_pe?
+    install_pe
+  else
+    install_puppet
+  end
+  hosts.each do |host|
+    on hosts, "mkdir -p #{host['distmoduledir']}"
+  end
+end
+
+RSpec.configure do |c|
+  # Project root
+  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+  fixture_path = File.expand_path(File.join(proj_root, 'spec', 'fixtures'))
+
+  # Readable test descriptions
+  c.formatter = :documentation
+
+  # Configure all nodes in nodeset
+  c.before :suite do
+    # Install module and dependencies
+    puppet_module_install(:source => proj_root, :module_name => 'composer')
+    hosts.each do |host|
+      # Add github token to hieradata, if applicable
+      hieradata = File.join(fixture_path, 'puppet', 'common.yaml')
+      if File.exists?(hieradata) then
+        scp_to host, hieradata, '/var/lib/hiera/common.yaml'
+      end
+      on host, puppet('module', 'install', 'puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module', 'install', 'puppetlabs-git'), { :acceptable_exit_codes => [0,1] }
+    end
+  end
+end


### PR DESCRIPTION
This PR contains an initial setup for [Beaker](https://github.com/puppetlabs/beaker) acceptance tests, an acceptance test for `composer::project`, and some simple docs on how to beaker, including how to incorporate your GitHub auth token into beaker via hiera.

**Note:** Beaker's dependencies do not seem to play nice with `ruby-1.8.7`, so those Travis builds will likely fail.