### PR TITLE
Add --no-interaction to composer::project

### DIFF
--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -105,7 +105,7 @@ define composer::project(
   $or_rm_command = "${end_command}${v} || rm -rf ${target_dir}"
 
   exec { $exec_name:
-    command => "${concat_cmd} create-project ${or_rm_command}",
+    command => "${concat_cmd} --no-interaction create-project ${or_rm_command}",
     tries   => $tries,
     timeout => $timeout,
     creates => $target_dir,

--- a/spec/defines/composer_project_spec.rb
+++ b/spec/defines/composer_project_spec.rb
@@ -20,7 +20,7 @@ describe 'composer::project' do
 
         it {
           should contain_exec('composer_create_project_myproject').without_user.with({
-            :command => "php /usr/local/bin/composer --stability=dev create-project projectzzz /my/subpar/project || rm -rf /my/subpar/project",
+            :command => "php /usr/local/bin/composer --stability=dev --no-interaction create-project projectzzz /my/subpar/project || rm -rf /my/subpar/project",
             :tries   => 3,
             :timeout => 1200,
             :creates => '/my/subpar/project',
@@ -51,7 +51,7 @@ describe 'composer::project' do
 
         it {
           should contain_exec('composer_create_project_whoadawg').with({
-            :command => %r{php /usr/local/bin/composer --stability=dev --repository-url=git@github.com:trollface/whoadawg.git --prefer-source --keep-vcs --working-dir=/my/working-dir create-project whoadawg99 /my/mediocre/project 0.0.8 || rm -rf /my/subpar/project},
+            :command => %r{php /usr/local/bin/composer --stability=dev --repository-url=git@github.com:trollface/whoadawg.git --prefer-source --keep-vcs --working-dir=/my/working-dir --no-interaction create-project whoadawg99 /my/mediocre/project 0.0.8 || rm -rf /my/subpar/project},
             :tries   => 2,
             :timeout => 600,
             :creates => '/my/mediocre/project',


### PR DESCRIPTION
Since puppet is running in a non interactive environment, if there is
any action required by user when creating the project, module will fail
to create the project. Adding --no-interaction will allow composer to
fallback to use the default value.
Here is an example:
http://symfony.com/blog/new-in-symfony-2-3-interactive-management-of-the-parameters-yml-file