### PR TITLE
Add user parameter to init.pp

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ class { 'composer':
     suhosin_enabled => true,
     auto_update     => false, # Set to true to automatically update composer to the latest version
     github_token    => '1234567890abcdefgh',
+    user            => 'app',
 }
 ```
 

--- a/manifests/exec.pp
+++ b/manifests/exec.pp
@@ -30,7 +30,7 @@ define composer::exec (
   $refreshonly              = false,
   $lock                     = false,
   $timeout                  = undef,
-  $user                     = undef,
+  $user                     = $composer::user,
   $global                   = false,
   $working_dir              = undef,
   $onlyif                   = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,6 +49,9 @@
 # [*auto_update*]
 #   If the composer binary should automatically be updated on each run
 #
+# [*user*]
+#   The user name to exec the composer commands as. Default is undefined.
+#
 # === Authors
 #
 # Thomas Ploch <profiploch@gmail.com>
@@ -68,6 +71,7 @@ class composer(
   $auto_update     = $composer::params::auto_update,
   $projects        = hiera_hash('composer::execs', {}),
   $github_token    = undef,
+  $user            = undef,
 ) inherits ::composer::params {
 
   require ::stdlib
@@ -205,6 +209,7 @@ class composer(
       command => "${composer_path} ${github_config} ${github_token}",
       cwd     => $tmp_path,
       require => File["${target_dir}/${composer_file}"],
+      user    => $user,
       unless  => "${composer_path} ${github_config}|grep ${github_token}",
     }
   }

--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -28,7 +28,7 @@
 #   The Package name of the PHP CLI package.
 #
 # [*user*]
-#   The user name to exec the composer commands as. Default is undefined.
+#   The user name to exec the composer commands as. Default is composer::user.
 #
 # [*working_dir*]
 #   Use the given directory as working directory.
@@ -52,7 +52,7 @@ define composer::project(
   $keep_vcs       = false,
   $tries          = 3,
   $timeout        = 1200,
-  $user           = undef,
+  $user           = $composer::user,
   $working_dir    = undef,
 ) {
   require ::composer


### PR DESCRIPTION
This allow auth.json and config.json to be created under the same user
as in project/exec calls. Because auth.json and config.json is created
with permission of 700, by default, they will be created for root user
(the default user). When user parameter is specified in project/exec,
composer are executed under non-root user and will get access denied
error.

When using this parameter, composer_home has also be set to a directory
that the user can read from. e.g. /tmp or /home/USER