### PR TITLE
Adds "S" flag to curl command

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -96,7 +96,7 @@ class composer(
   # download composer
   case $download_method {
     'curl': {
-      $download_command = "curl -s https://getcomposer.org/installer | ${composer::php_bin}"
+      $download_command = "curl -sS https://getcomposer.org/installer | ${composer::php_bin}"
       $download_require = $suhosin_enabled ? {
         false    => [ Package['curl', $php_package] ],
         default  => [


### PR DESCRIPTION
Seems composer stopped installing without the `-S` flag:

    [03:53 PM]-[vagrant@local]-[/tmp]
    $ curl -s http://getcomposer.org/installer | php
    <html>
    <head><title>302 Found</title></head>
    <body bgcolor="white">
    <center><h1>302 Found</h1></center>
    <hr><center>nginx</center>
    </body>
    </html>

Per their website, they list `curl -sS https://getcomposer.org/installer | php`.

    [03:54 PM]-[vagrant@local]-[/tmp]
    $ curl -sS https://getcomposer.org/installer | php
    #!/usr/bin/env php
    All settings correct for using Composer
    Downloading...
    
    Composer successfully installed to: /tmp/composer.phar
    Use it: php composer.phar

This has been working fine until now, I think it's best if we use their recommended install string.