### PR TITLE
Fix line endings for files deployed from windows hosts.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Files copied to linux hosts should have linux line endings
+*.erb text eol=lf


### PR DESCRIPTION
When I checkout the repository on a windows host, git may change the line endings to windows line endings. When puppet then deploys that file on the host, linux line endings are expected, and windows line endings may not work.