### PR TITLE
Add support for Composer’s --ignore-platform-reqs option

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ composer::exec { 'silex-update':
     dry_run              => false, # Just simulate actions
     custom_installers    => false, # No custom installers
     scripts              => false, # No script execution
+    ignore_platform_reqs => false, # Ignore platform requirements
     interaction          => false, # No interactive questions
     optimize             => false, # Optimize autoloader
     dev                  => true, # Install dev dependencies
@@ -130,6 +131,7 @@ composer::exec { 'silex-install':
     dry_run              => false, # Just simulate actions
     custom_installers    => false, # No custom installers
     scripts              => false, # No script execution
+    ignore_platform_reqs => false, # Ignore platform requirements
     interaction          => false, # No interactive questions
     optimize             => false, # Optimize autoloader
     dev                  => true, # Install dev dependencies

--- a/manifests/exec.pp
+++ b/manifests/exec.pp
@@ -20,6 +20,7 @@ define composer::exec (
   $custom_installers        = false,
   $scripts                  = false,
   $optimize                 = false,
+  $ignore_platform_reqs     = false,
   $interaction              = false,
   $dev                      = true,
   $no_update                = false,
@@ -41,8 +42,8 @@ define composer::exec (
   validate_string($cmd, $cwd)
   validate_bool(
     $lock, $prefer_source, $prefer_dist, $dry_run,
-    $custom_installers, $scripts, $optimize, $interaction, $dev,
-    $verbose, $refreshonly
+    $custom_installers, $scripts, $optimize, $ignore_platform_reqs,
+    $interaction, $dev, $verbose, $refreshonly
   )
   validate_array($packages)
 

--- a/templates/install.erb
+++ b/templates/install.erb
@@ -4,6 +4,7 @@
 <% if @working_dir %> --working-dir=<%= @working_dir%><%end -%>
 <% unless @custom_installers %> --no-plugins<% end -%>
 <% unless @scripts %> --no-scripts<% end -%>
+<% if @ignore_platform_reqs %> --ignore-platform-reqs<% end -%>
 <% unless @interaction %> --no-interaction<% end -%>
 <% if @dev %> --dev<% end -%>
 <% if @verbose %> -v<% end -%>

--- a/templates/update.erb
+++ b/templates/update.erb
@@ -4,6 +4,7 @@
 <% if @working_dir %> --working-dir=<%= @working_dir%><%end -%>
 <% unless @custom_installers %> --no-plugins<% end -%>
 <% unless @scripts %> --no-scripts<% end -%>
+<% if @ignore_platform_reqs %> --ignore-platform-reqs<% end -%>
 <% unless @interaction %> --no-interaction<% end -%>
 <% unless @dev %> --no-dev<% end -%>
 <% if @verbose %> -v<% end -%>

--- a/templates/update.erb.rej
+++ b/templates/update.erb.rej
@@ -1,0 +1,9 @@
+diff a/templates/update.erb b/templates/update.erb	(rejected hunks)
+@@ -3,6 +3,7 @@
+ <% if @prefer_dist %> --prefer-dist<% end -%>
+ <% unless @custom_installers %> --no-plugins<% end -%>
+ <% unless @scripts %> --no-scripts<% end -%>
++<% if @ignore_platform_reqs %> --ignore-platform-reqs<% end -%>
+ <% unless @interaction %> --no-interaction<% end -%>
+ <% unless @dev %> --no-dev<% end -%>
+ <% if @verbose %> -v<% end -%>

--- a/templates/update.erb.rej
+++ b/templates/update.erb.rej
@@ -1,9 +1,0 @@
-diff a/templates/update.erb b/templates/update.erb	(rejected hunks)
-@@ -3,6 +3,7 @@
- <% if @prefer_dist %> --prefer-dist<% end -%>
- <% unless @custom_installers %> --no-plugins<% end -%>
- <% unless @scripts %> --no-scripts<% end -%>
-+<% if @ignore_platform_reqs %> --ignore-platform-reqs<% end -%>
- <% unless @interaction %> --no-interaction<% end -%>
- <% unless @dev %> --no-dev<% end -%>
- <% if @verbose %> -v<% end -%>


### PR DESCRIPTION
I had a need to use Composer's --ignore-platform-reqs option. This commit adds support for it.