### PR TITLE
use $composer_file instead of hardcoded file (wget)

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -107,7 +107,7 @@ class composer(
       $method_package = $curl_package
     }
     'wget': {
-      $download_command = 'wget https://getcomposer.org/composer.phar -O composer.phar'
+      $download_command = "wget https://getcomposer.org/composer.phar -O ${composer_file}"
       $download_require = $suhosin_enabled ? {
         false   => [ Package['wget', $php_package] ],
         default => [


### PR DESCRIPTION
If you use wget as download method and set $composer_file to "composer", then resource "move_composer_" will fail. 

`class { '::composer':
    target_dir      => '/usr/bin',
    composer_file   => 'composer', # could also be 'composer.phar'
    download_method => 'wget',     # or 'curl'
    logoutput       => false,
    tmp_path        => '/tmp',
    php_package     => 'php5',
    curl_package    => 'curl',
    wget_package    => 'wget',
    composer_home   => '/usr/local/share/composer',
    php_bin         => 'php', # could also i.e. be 'php -d "apc.enable_cli=0"' for more fine grained control
    suhosin_enabled => false,
    auto_update     => false, # Set to true to automatically update composer to the latest version
    user            => 'root'
  }`
`

Resource "move_composer_" expected file "${tmp_path}/${composer_file}", but wget save to "composer.phar" as you can see in diff.
