### PR TITLE
Fix tests in travis as rake 11.0.0 now requires ruby 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 before_install:
   - gem update bundler
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 cache: bundler
 before_install:
+  - rm Gemfile.lock || true
   - gem update bundler
 rvm:
   - 2.1.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,21 @@
+---
 language: ruby
 cache: bundler
 before_install:
   - rm Gemfile.lock || true
   - gem update bundler
 rvm:
-  - 2.1.4
-  - 2.0.0
+  - 2.1
+  - 2.0
   - 1.9.3
   - 1.8.7
+bundler_args: --without test
+
 before_script:
+script:
+  - bundle exec rake spec
 after_script:
-script: "bundle exec rake spec"
-bundler_args: --without acceptance
+
 env:
   - PUPPET_VERSION=2.7.25
   - PUPPET_VERSION=3.1.1
@@ -25,17 +29,17 @@ matrix:
     - rvm: ruby-head
     - env: PUPPET_VERSION=3.7.3 FUTURE_PARSER="yes"
   exclude:
-    - rvm: 2.0.0
+    - rvm: 2.0
       env: PUPPET_VERSION=2.7.25
-    - rvm: 2.0.0
+    - rvm: 2.0
       env: PUPPET_VERSION=3.1.1
-    - rvm: 2.1.4
+    - rvm: 2.1
       env: PUPPET_VERSION=2.7.25
-    - rvm: 2.1.4
+    - rvm: 2.1
       env: PUPPET_VERSION=3.1.1
-    - rvm: 2.1.4
+    - rvm: 2.1
       env: PUPPET_VERSION=3.2.4
-    - rvm: 2.1.4
+    - rvm: 2.1
       env: PUPPET_VERSION=3.3.2
   fast_finish: true
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-#ruby=1.9.3@puppet-composer
+source 'https://rubygems.org'
 
 if ENV.key?('PUPPET_VERSION')
   puppetversion = "= #{ENV['PUPPET_VERSION']}"
@@ -6,18 +6,20 @@ else
   puppetversion = ['>= 2.7']
 end
 
-source 'https://rubygems.org'
-
 gem 'puppet', puppetversion
 gem 'puppetlabs_spec_helper'
-gem 'rspec-puppet', :github => 'rodjek/rspec-puppet', :ref => '28c29d09e47211b65c0969b55082367a71d2e073'
+gem 'rspec-puppet', :github => 'rodjek/rspec-puppet'
 gem 'rspec', '< 3.0.0'
 gem 'mocha'
 gem 'puppet-lint'
 gem 'hiera'
 gem 'hiera-puppet'
 
-group :acceptance do
-  gem 'beaker'
-  gem 'beaker-rspec'
+group :test do
+  gem 'beaker',                        :require => false
+  gem 'beaker-rspec',                  :require => false
+  gem 'beaker-puppet_install_helper',  :require => false
+  if RUBY_VERSION =~ /^1\.8/
+    gem 'rake', '< 11'
+  end
 end


### PR DESCRIPTION
Ref: https://github.com/ruby/rake/commit/4ab6eba0d77c7e2d449e9292673099e2f10e193b#diff-cb3e0f2c76a671c083e8f001970f4631